### PR TITLE
Updates & changes on atomic counters

### DIFF
--- a/src/fragile.rs
+++ b/src/fragile.rs
@@ -3,13 +3,13 @@ use std::cmp;
 use std::fmt;
 use std::mem;
 use std::mem::ManuallyDrop;
-use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use errors::InvalidThreadAccess;
 
 fn next_thread_id() -> usize {
-    static mut COUNTER: AtomicUsize = ATOMIC_USIZE_INIT;
-    unsafe { COUNTER.fetch_add(1, Ordering::SeqCst) }
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    COUNTER.fetch_add(1, Ordering::Relaxed)
 }
 
 pub(crate) fn get_thread_id() -> usize {

--- a/src/sticky.rs
+++ b/src/sticky.rs
@@ -4,13 +4,13 @@ use std::collections::HashMap;
 use std::fmt;
 use std::marker::PhantomData;
 use std::mem;
-use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use errors::InvalidThreadAccess;
 
 fn next_item_id() -> usize {
-    static mut COUNTER: AtomicUsize = ATOMIC_USIZE_INIT;
-    unsafe { COUNTER.fetch_add(1, Ordering::SeqCst) }
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    COUNTER.fetch_add(1, Ordering::Relaxed)
 }
 
 struct Registry(HashMap<usize, (UnsafeCell<*mut ()>, Box<Fn(&UnsafeCell<*mut ()>)>)>);


### PR DESCRIPTION
- Use `AtomicUsize::new(0)` instead of the now deprecated initialization constant
- Make the static immutable as atomics do not need mutability, and remove the now unneeded unsafe blocks
- Make the counters' atomic ordering relaxed